### PR TITLE
fix infinite loop in video pagination saga

### DIFF
--- a/src/sagas/videos.js
+++ b/src/sagas/videos.js
@@ -32,7 +32,7 @@ function* onVideosInit({ payload = {} }) {
       put({
         type: videoTypes.VIDEOS_INIT,
         payload: {
-          skip: payload.skip || 0 + perPage
+          skip: (payload.skip || 0) + perPage
         }
       })
     ]);


### PR DESCRIPTION
Operator precedence bug caused skip offset to never advance past 100, resulting in the same Contentful page being fetched indefinitely.